### PR TITLE
add Dockerfile for building/running u2fval

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:2.7.10
+
+WORKDIR /u2fval
+
+# install prerequisites for u2fval
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libssl-dev \
+                                               python-m2crypto \
+                                               swig \
+                                               sqlite3
+
+# jessie has the opensslcon.h in a different place than M2Crypto expects
+RUN ln -s /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl/
+
+ADD . /u2fval
+
+# build u2fval
+RUN python setup.py install
+
+# create a source distribution
+RUN python setup.py sdist
+
+# copy default configuration into place
+COPY conf/u2fval.conf /etc/yubico/u2fval/
+
+# create db
+RUN u2fval db init
+
+EXPOSE 8080
+
+# run u2fval accepting connections on all interfaces
+CMD [ "u2fval", "run", "-i", "0.0.0.0" ]


### PR DESCRIPTION
I found it useful to experiment with u2fval using a Docker container built with this Dockerfile, so I'm offering it upstream. :smile:

It's fairly simple right now and definitely could be improved over time, but at least this gives people a starting place to use u2fval more easily.

All you need to do is:

- install Docker
- `docker build -t u2fval .`
- `docker run --run --name u2fval --rm -p <host port>:8080 u2fval`