### PR TITLE
replace werkzeug.contrib.cache with cachelib

### DIFF
--- a/u2fval/view.py
+++ b/u2fval/view.py
@@ -4,7 +4,7 @@ from . import app, exc
 from .model import db, Client, User
 from .transactiondb import DBStore
 from flask import g, request, jsonify
-from werkzeug.contrib.cache import SimpleCache, MemcachedCache
+from cachelib import SimpleCache, MemcachedCache
 from u2flib_server.utils import websafe_decode
 from u2flib_server.u2f import (begin_registration, complete_registration,
                                begin_authentication, complete_authentication)


### PR DESCRIPTION
see:
https://github.com/pallets/werkzeug/issues/1249
https://github.com/Azure-Samples/ms-identity-python-webapp/issues/16

these APIs have been removed in werkzeug-1.x, and typical u2fval installed via pip will install that version.